### PR TITLE
add not_weighted extension type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ std::unordered_map<std::string, int> data_type_dic{  // use this data_type
     {"gap", 2}, 
     {"coverage", 3},
     {"coverage_avg", 4},
-    {"telomere", 5}
+    {"telomere", 5},
+    {"not_weighted", 6}
 };
 ```
 - `0`: default, just add the weighted value of every bin to the `graph->values[index]`;
@@ -74,6 +75,7 @@ std::unordered_map<std::string, int> data_type_dic{  // use this data_type
 - `3`: coverage, the weighted value of every bin is added to `graph->values[index]`
 - `4`: averaged coverage, the weighted value of every bin is added to `graph->values[index]`
 - `5`: telomere, the weighted value of every bin is added to `graph->values[index]`
+- `6`: not_weighted, if `not` and `weighted` are both contained in the extension name, then the extension will not be weighted while accumulating the value. NOTE: while the supported maximum value for the extension is `u32` which should be not more than `2^32 - 1` or there will be un-expected problem.
 
 
 # Requirments, running

--- a/logs/0.0.8.md
+++ b/logs/0.0.8.md
@@ -2,4 +2,5 @@
 
 - Severe bug fixed: extension value gradually drop while traversing the extension. This is cause by `u32 bp_per_pixel`, which should be `float` instead of `integeer`, or the numerical error errors due to decimals will accumulate. 
 - add noise filter to process `coverage` and `repeat_density`.
-- Update extension types: `{"default", 0}, {"repeat_density", 1}, {"gap", 2}, {"coverage", 3}, {"coverage_avg", 4}, {"telomere", 5}`
+- Update extension types: `{"default", 0}, {"repeat_density", 1}, {"gap", 2}, {"coverage", 3}, {"coverage_avg", 4}, {"telomere", 5}, {"not_weighted", 6}`
+- Not_weighted extension: https://github.com/sanger-tol/PretextGraph/issues/3


### PR DESCRIPTION
if `not` and `weighted` contained within the name of extension, then this extension will be accumulated without being averaged by the `bin_size` or `bp_per_pixel`